### PR TITLE
Fix issue #15, added listener for ACTION_DOWN

### DIFF
--- a/RippleView/src/com/indris/material/RippleView.java
+++ b/RippleView/src/com/indris/material/RippleView.java
@@ -117,6 +117,29 @@ public class RippleView extends Button {
                     .setDuration(400);
             mRadiusAnimator
                     .setInterpolator(new AccelerateDecelerateInterpolator());
+            mRadiusAnimator.addListener(new Animator.AnimatorListener() {
+                @Override
+                public void onAnimationStart(Animator animator) {
+                    mIsAnimating = true;
+                }
+
+                @Override
+                public void onAnimationEnd(Animator animator) {
+                    setRadius(0);
+                    ViewHelper.setAlpha(RippleView.this, 1);
+                    mIsAnimating = false;
+                }
+
+                @Override
+                public void onAnimationCancel(Animator animator) {
+
+                }
+
+                @Override
+                public void onAnimationRepeat(Animator animator) {
+
+                }
+            });
             mRadiusAnimator.start();
             if (!superResult) {
                 return true;


### PR DESCRIPTION
Added line 120-142, listener for ACTION_DOWN animation.

This update ensures the mIsAnimating status to be true when the animation starts, so as when ACTION_UP happens `mRadiusAnimator.cancel()` goes off before a new ObjectAnimator is created.